### PR TITLE
Added fix for nullability in Objective C apps that bridge to Swift

### DIFF
--- a/AWSCore/Authentication/AWSSignature.h
+++ b/AWSCore/Authentication/AWSSignature.h
@@ -16,6 +16,7 @@
 #import <Foundation/Foundation.h>
 #import "AWSNetworking.h"
 
+NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXPORT NSString *const AWSSignatureV4Algorithm;
 FOUNDATION_EXPORT NSString *const AWSSignatureV4Terminator;
 
@@ -143,4 +144,5 @@ FOUNDATION_EXPORT NSString *const AWSSignatureV4Terminator;
  **/
 + (NSUInteger)computeContentLengthForChunkedData:(NSUInteger)dataLength;
 
+NS_ASSUME_NONNULL_END
 @end


### PR DESCRIPTION
This PR added NS_ASSUME_NONNULL block to header to make compatible with swift nullable parameters. There is a current open issue in the main repo to fix this permanently.

[Issue 2001](https://github.com/aws-amplify/aws-sdk-ios/issues/2001)